### PR TITLE
Add math.h header to Lightmaputil.cpp

### DIFF
--- a/src/LightmapUtil.cpp
+++ b/src/LightmapUtil.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <filesystem>
 #include <cstring>
+#include <math.h>
 
 #include "LightmapUtil.h"
 

--- a/src/LightmapUtil.cpp
+++ b/src/LightmapUtil.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <filesystem>
 #include <cstring>
-#include <math.h>
+#include <cmath>
 
 #include "LightmapUtil.h"
 


### PR DESCRIPTION
I get this error without <math.h> being in headers, so I added it in this pull request.
```
[ 50%] Building CXX object CMakeFiles/lightmaputil.dir/src/LightmapUtil.cpp.o
/home/hurricane/LightmapUtil/src/LightmapUtil.cpp: In function ‘void checkSampleNeighbors(int, int, bool&, bool&)’:
/home/hurricane/LightmapUtil/src/LightmapUtil.cpp:444:73: error: ‘pow’ was not declared in this scope
  444 |                 float sample1R = dlightdataLDR[ lightmapSample1 ].r * ( pow( 2.0f, sample1E ) / 255 );
      |                                                                         ^~~
/home/hurricane/LightmapUtil/src/LightmapUtil.cpp:464:76: error: ‘pow’ was not declared in this scope
  464 |                 float HDRsample1R = dlightdataHDR[ lightmapSample1 ].r * ( pow( 2.0f, HDRsample1E ) / 255 );
      |                                                                            ^~~
make[2]: *** [CMakeFiles/lightmaputil.dir/build.make:76: CMakeFiles/lightmaputil.dir/src/LightmapUtil.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/lightmaputil.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```