### PR TITLE
add aur packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LightmapUtil
 
+![AUR maintainer](https://img.shields.io/aur/maintainer/lightmaputil-git)
+
 A simple command line utility to tell you if your lightmaps are too high resolution (and maybe more soon?)
 
 ## Usage


### PR DESCRIPTION
this pr will advertise the [aur package](https://aur.archlinux.org/packages/lightmaputil-git) for the project, allowing for easy install options right up front 👯 